### PR TITLE
Rename cache to pool

### DIFF
--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityBuilder.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityBuilder.java
@@ -37,19 +37,19 @@ public class EntityBuilder implements MutableComponentContainer {
     private static final Logger logger = LoggerFactory.getLogger(EntityBuilder.class);
 
     private Map<Class<? extends Component>, Component> components = Maps.newHashMap();
-    private EntityCache cache;
+    private EntityPool pool;
     private EngineEntityManager entityManager;
 
     private boolean sendLifecycleEvents = true;
 
     public EntityBuilder(EngineEntityManager entityManager) {
         this.entityManager = entityManager;
-        this.cache = entityManager.getGlobalCache();
+        this.pool = entityManager.getGlobalPool();
     }
 
-    public EntityBuilder(EngineEntityManager entityManager, EntityCache cache) {
+    public EntityBuilder(EngineEntityManager entityManager, EntityPool pool) {
         this.entityManager = entityManager;
-        this.cache = cache;
+        this.pool = pool;
     }
 
     /**
@@ -94,11 +94,11 @@ public class EntityBuilder implements MutableComponentContainer {
      * @return The built entity.
      */
     public EntityRef build() {
-        return cache.create(components.values(), sendLifecycleEvents);
+        return pool.create(components.values(), sendLifecycleEvents);
     }
 
     public EntityRef buildWithoutLifecycleEvents() {
-        return cache.create(components.values(), false);
+        return pool.create(components.values(), false);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 /**
  */
-public interface EntityManager extends EntityCache {
+public interface EntityManager extends EntityPool {
 
     /**
      * Creates a new EntityRef in sector-scope
@@ -73,7 +73,7 @@ public interface EntityManager extends EntityCache {
      */
     ComponentLibrary getComponentLibrary();
 
-    EntityCache getGlobalCache();
+    EntityPool getGlobalPool();
 
     SectorManager getSectorManager();
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
@@ -22,10 +22,10 @@ import org.terasology.math.geom.Vector3f;
 
 /**
  */
-public interface EntityCache {
+public interface EntityPool {
 
     /**
-     * Removes all entities from the cache.
+     * Removes all entities from the pool.
      */
     void clear();
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/SectorManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/SectorManager.java
@@ -17,5 +17,5 @@ package org.terasology.entitySystem.entity;
 
 /**
  */
-public interface SectorManager extends EntityCache {
+public interface SectorManager extends EntityPool {
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
@@ -23,7 +23,7 @@ import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 
 /**
  */
-public interface EngineEntityManager extends LowLevelEntityManager, EngineEntityCache {
+public interface EngineEntityManager extends LowLevelEntityManager, EngineEntityPool {
 
     void setEntityRefStrategy(RefStrategy strategy);
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityPool.java
@@ -16,13 +16,13 @@
 package org.terasology.entitySystem.entity.internal;
 
 import org.terasology.entitySystem.Component;
-import org.terasology.entitySystem.entity.EntityCache;
+import org.terasology.entitySystem.entity.EntityPool;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.prefab.Prefab;
 
 /**
  */
-public interface EngineEntityCache extends EntityCache {
+public interface EngineEntityPool extends EntityPool {
 
     /**
      * Creates an entity but doesn't send any lifecycle events.

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineSectorManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineSectorManager.java
@@ -19,5 +19,5 @@ import org.terasology.entitySystem.entity.SectorManager;
 
 /**
  */
-public interface EngineSectorManager extends SectorManager, EngineEntityCache {
+public interface EngineSectorManager extends SectorManager, EngineEntityPool {
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityIterator.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityIterator.java
@@ -16,7 +16,7 @@
 package org.terasology.entitySystem.entity.internal;
 
 import gnu.trove.iterator.TLongIterator;
-import org.terasology.entitySystem.entity.EntityCache;
+import org.terasology.entitySystem.entity.EntityPool;
 import org.terasology.entitySystem.entity.EntityRef;
 
 import java.util.Iterator;
@@ -26,11 +26,11 @@ import java.util.Iterator;
  */
 public class EntityIterator implements Iterator<EntityRef> {
     private TLongIterator idIterator;
-    private EntityCache cache;
+    private EntityPool pool;
 
-    EntityIterator(TLongIterator idIterator, EntityCache cache) {
+    EntityIterator(TLongIterator idIterator, EntityPool pool) {
         this.idIterator = idIterator;
-        this.cache = cache;
+        this.pool = pool;
     }
 
     @Override
@@ -40,7 +40,7 @@ public class EntityIterator implements Iterator<EntityRef> {
 
     @Override
     public EntityRef next() {
-        return cache.createEntityRefWithId(idIterator.next());
+        return pool.createEntityRefWithId(idIterator.next());
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
@@ -42,16 +42,16 @@ import static org.terasology.entitySystem.entity.internal.PojoEntityManager.NULL
 
 /**
  */
-public class PojoEntityCache implements EngineEntityCache {
+public class PojoEntityPool implements EngineEntityPool {
 
     private PojoEntityManager entityManager;
 
-    private static final Logger logger = LoggerFactory.getLogger(PojoEntityCache.class);
+    private static final Logger logger = LoggerFactory.getLogger(PojoEntityPool.class);
 
     private Map<Long, BaseEntityRef> entityStore = new MapMaker().weakValues().concurrencyLevel(4).initialCapacity(1000).makeMap();
     private ComponentTable componentStore = new ComponentTable();
 
-    public PojoEntityCache(PojoEntityManager entityManager) {
+    public PojoEntityPool(PojoEntityManager entityManager) {
         this.entityManager = entityManager;
     }
 
@@ -347,16 +347,16 @@ public class PojoEntityCache implements EngineEntityCache {
         }
         EntityRef existing = entityManager.getEntity(entityId);
         if (existing != null) {
-            //Entity exists, but is not in this cache
+            //Entity exists, but is not in this pool
             return existing;
         }
-        //Todo: look into whether RefStrategy should use manager or cache?
+        //Todo: look into whether RefStrategy should use manager or pool?
         BaseEntityRef newRef = entityManager.getEntityRefStrategy().createRefFor(entityId, entityManager);
 
         if (newRef.getComponent(EntityInfoComponent.class).scope == EntityData.Entity.Scope.SECTOR) {
-            entityManager.assignToCache(newRef, entityManager.getSectorManager());
+            entityManager.assignToPool(newRef, entityManager.getSectorManager());
         } else {
-            entityManager.assignToCache(newRef, entityManager);
+            entityManager.assignToPool(newRef, entityManager);
         }
 
         entityStore.put(entityId, newRef);

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
@@ -18,9 +18,8 @@ package org.terasology.entitySystem.entity.internal;
 import com.google.common.collect.Iterables;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityBuilder;
-import org.terasology.entitySystem.entity.EntityCache;
+import org.terasology.entitySystem.entity.EntityPool;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.entity.SectorManager;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
@@ -32,20 +31,20 @@ import java.util.List;
  */
 public class PojoSectorManager implements EngineSectorManager {
 
-    private List<EngineEntityCache> caches;
+    private List<EngineEntityPool> pools;
 
     private PojoEntityManager entityManager;
 
     public PojoSectorManager(PojoEntityManager entityManager) {
         this.entityManager = entityManager;
-        caches = new ArrayList<>();
-        caches.add(new PojoEntityCache(entityManager));
+        pools = new ArrayList<>();
+        pools.add(new PojoEntityPool(entityManager));
     }
 
     @Override
     public void clear() {
-        for (EntityCache cache : caches) {
-            cache.clear();
+        for (EntityPool pool : pools) {
+            pool.clear();
         }
     }
 
@@ -72,97 +71,97 @@ public class PojoSectorManager implements EngineSectorManager {
 
     @Override
     public EntityRef create() {
-        return getCache().create();
+        return getPool().create();
     }
 
     @Override
     public EntityRef create(Component... components) {
-        return getCache().create(components);
+        return getPool().create(components);
     }
 
     @Override
     public EntityRef create(Iterable<Component> components) {
-        return getCache().create(components);
+        return getPool().create(components);
     }
 
     @Override
     public EntityRef create(Iterable<Component> components, boolean sendLifecycleEvents) {
-        return getCache().create(components, sendLifecycleEvents);
+        return getPool().create(components, sendLifecycleEvents);
     }
 
     @Override
     public EntityRef create(String prefabName) {
-        return getCache().create(prefabName);
+        return getPool().create(prefabName);
     }
 
     @Override
     public EntityRef create(Prefab prefab) {
-        return getCache().create(prefab);
+        return getPool().create(prefab);
     }
 
     @Override
     public EntityRef create(String prefab, Vector3f position) {
-        return getCache().create(prefab, position);
+        return getPool().create(prefab, position);
     }
 
     @Override
     public EntityRef create(Prefab prefab, Vector3f position) {
-        return getCache().create(prefab, position);
+        return getPool().create(prefab, position);
     }
 
     @Override
     public EntityRef create(Prefab prefab, Vector3f position, Quat4f rotation) {
-        return getCache().create(prefab, position, rotation);
+        return getPool().create(prefab, position, rotation);
     }
 
     @Override
     public EntityRef createEntityWithoutLifecycleEvents(Iterable<Component> components) {
-        return getCache().createEntityWithoutLifecycleEvents(components);
+        return getPool().createEntityWithoutLifecycleEvents(components);
     }
 
     @Override
     public EntityRef createEntityWithoutLifecycleEvents(String prefab) {
-        return getCache().createEntityWithoutLifecycleEvents(prefab);
+        return getPool().createEntityWithoutLifecycleEvents(prefab);
     }
 
     @Override
     public EntityRef createEntityWithoutLifecycleEvents(Prefab prefab) {
-        return getCache().createEntityWithoutLifecycleEvents(prefab);
+        return getPool().createEntityWithoutLifecycleEvents(prefab);
     }
 
     @Override
     public void putEntity(long entityId, BaseEntityRef ref) {
-        getCache().putEntity(entityId, ref);
+        getPool().putEntity(entityId, ref);
     }
 
     @Override
     public ComponentTable getComponentStore() {
-        return getCache().getComponentStore();
+        return getPool().getComponentStore();
     }
 
     @Override
     public EntityRef createEntityWithId(long id, Iterable<Component> components) {
-        return getCache().createEntityWithId(id, components);
+        return getPool().createEntityWithId(id, components);
     }
 
     @Override
     public EntityRef createEntityRefWithId(long id) {
-        return getCache().createEntityRefWithId(id);
+        return getPool().createEntityRefWithId(id);
     }
 
     public void destroy(long entityId) {
-        getCache().destroy(entityId);
+        getPool().destroy(entityId);
     }
 
     public void destroyEntityWithoutEvents(EntityRef entity) {
-        getCache().destroyEntityWithoutEvents(entity);
+        getPool().destroyEntityWithoutEvents(entity);
     }
 
     @Override
     public Iterable<EntityRef> getAllEntities() {
         List<Iterable<EntityRef>> entityIterables = new ArrayList<>();
-        for (EntityCache cache : caches) {
-            entityIterables.add(cache.getAllEntities());
+        for (EntityPool pool : pools) {
+            entityIterables.add(pool.getAllEntities());
         }
 
         return Iterables.concat(entityIterables);
@@ -171,8 +170,8 @@ public class PojoSectorManager implements EngineSectorManager {
     @Override
     public Iterable<EntityRef> getEntitiesWith(Class<? extends Component>... componentClasses) {
         List<Iterable<EntityRef>> entityIterables = new ArrayList<>();
-        for (EntityCache cache : caches) {
-            entityIterables.add(cache.getEntitiesWith(componentClasses));
+        for (EntityPool pool : pools) {
+            entityIterables.add(pool.getEntitiesWith(componentClasses));
         }
 
         return Iterables.concat(entityIterables);
@@ -181,8 +180,8 @@ public class PojoSectorManager implements EngineSectorManager {
     @Override
     public int getCountOfEntitiesWith(Class<? extends Component>[] componentClasses) {
         int i = 0;
-        for (EngineEntityCache cache : caches) {
-            i += cache.getCountOfEntitiesWith(componentClasses);
+        for (EngineEntityPool pool : pools) {
+            i += pool.getCountOfEntitiesWith(componentClasses);
         }
         return i;
     }
@@ -190,8 +189,8 @@ public class PojoSectorManager implements EngineSectorManager {
     @Override
     public int getActiveEntityCount() {
         int count = 0;
-        for (EntityCache cache : caches) {
-            count += cache.getActiveEntityCount();
+        for (EntityPool pool : pools) {
+            count += pool.getActiveEntityCount();
         }
         return count;
     }
@@ -199,8 +198,8 @@ public class PojoSectorManager implements EngineSectorManager {
     @Override
     public EntityRef getExistingEntity(long id) {
         EntityRef entity;
-        for (EntityCache cache : caches) {
-            entity = cache.getExistingEntity(id);
+        for (EntityPool pool : pools) {
+            entity = pool.getExistingEntity(id);
             if (entity != EntityRef.NULL && entity != null) {
                 return entity;
             }
@@ -208,13 +207,13 @@ public class PojoSectorManager implements EngineSectorManager {
         return EntityRef.NULL;
     }
 
-    private EngineEntityCache getCache() {
-        return caches.get(0);
+    private EngineEntityPool getPool() {
+        return pools.get(0);
     }
 
     public boolean hasComponent(long entityId, Class<? extends Component> componentClass) {
-        for (EngineEntityCache cache : caches) {
-            if (cache.hasComponent(entityId, componentClass)) {
+        for (EngineEntityPool pool : pools) {
+            if (pool.hasComponent(entityId, componentClass)) {
                 return true;
             }
         }


### PR DESCRIPTION
This PR renames all instances of 'cache' to 'pool,' which is a more suitable name.

'Cache,' especially when related to computing, implies some form of saving/caching against a separate main store, which is not what they are doing. I think that 'pool' (suggested by @Cervator) is a more appropriate name, because all they are doing is splitting up the entity storage into multiple smaller, independent groups.