### PR TITLE
Bug fixes and method cleanup

### DIFF
--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
@@ -36,12 +36,6 @@ public interface EntityManager extends EntityPool {
     }
 
     /**
-     * @param id
-     * @return The entity with the given id, or the null entity
-     */
-    EntityRef getEntity(long id);
-
-    /**
      * @param other
      * @return A new entity with a copy of each of the other entity's components
      * @deprecated Use EntityRef.copy() instead.

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
@@ -149,7 +149,7 @@ public interface EntityPool {
      * @param id
      * @return The entityRef for the given id
      */
-    EntityRef getEntityRef(long id);
+    EntityRef getEntity(long id);
 
     Iterable<EntityRef> getAllEntities();
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
@@ -147,7 +147,7 @@ public interface EntityPool {
      * Retrieve the entity ref with the given id.
      *
      * @param id
-     * @return The entityRef for the given id
+     * @return the {@link EntityRef}, if it exists; {@link EntityRef#NULL} otherwise
      */
     EntityRef getEntity(long id);
 
@@ -169,13 +169,5 @@ public interface EntityPool {
      * @return A count of currently active entities
      */
     int getActiveEntityCount();
-
-    /**
-     * Gets an entity, if it already exists.
-     *
-     * @param id the id of the desired entity
-     * @return the {@link EntityRef}, if it exists; {@link EntityRef#NULL} otherwise
-     */
-    EntityRef getExistingEntity(long id);
 
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
@@ -144,12 +144,12 @@ public interface EntityPool {
     EntityRef createEntityWithId(long id, Iterable<Component> components);
 
     /**
-     * Creates an entity ref with the given id. This is used when loading components with references.
+     * Retrieve the entity ref with the given id.
      *
      * @param id
      * @return The entityRef for the given id
      */
-    EntityRef createEntityRefWithId(long id);
+    EntityRef getEntityRef(long id);
 
     Iterable<EntityRef> getAllEntities();
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
@@ -54,7 +54,7 @@ public interface EngineEntityManager extends LowLevelEntityManager, EngineEntity
      * @param id
      * @return The entityRef for the given id
      */
-    EntityRef createEntityRefWithId(long id);
+    EntityRef getEntityRef(long id);
 
     /**
      * This is used to persist the entity manager's state

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
@@ -54,7 +54,7 @@ public interface EngineEntityManager extends LowLevelEntityManager, EngineEntity
      * @param id
      * @return The entityRef for the given id
      */
-    EntityRef getEntityRef(long id);
+    EntityRef getEntity(long id);
 
     /**
      * This is used to persist the entity manager's state

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityIterator.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityIterator.java
@@ -40,7 +40,7 @@ public class EntityIterator implements Iterator<EntityRef> {
 
     @Override
     public EntityRef next() {
-        return pool.createEntityRefWithId(idIterator.next());
+        return pool.getEntityRef(idIterator.next());
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityIterator.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityIterator.java
@@ -40,7 +40,7 @@ public class EntityIterator implements Iterator<EntityRef> {
 
     @Override
     public EntityRef next() {
-        return pool.getEntityRef(idIterator.next());
+        return pool.getEntity(idIterator.next());
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -32,7 +32,6 @@ import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityPool;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeDeactivateComponent;
-import org.terasology.entitySystem.entity.lifecycleEvents.BeforeEntityCreated;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnAddedComponent;
@@ -162,35 +161,6 @@ public class PojoEntityManager implements EngineEntityManager {
     @Override
     public void setEntityRefStrategy(RefStrategy strategy) {
         this.refStrategy = strategy;
-    }
-
-    private EntityRef createEntity(Iterable<Component> components) {
-        long entityId = createEntity();
-
-        Prefab prefab = null;
-        for (Component component : components) {
-            if (component instanceof EntityInfoComponent) {
-                EntityInfoComponent comp = (EntityInfoComponent) component;
-                prefab = comp.parentPrefab;
-                break;
-            }
-        }
-
-        Iterable<Component> finalComponents;
-        if (eventSystem != null) {
-            BeforeEntityCreated event = new BeforeEntityCreated(prefab, components);
-            BaseEntityRef tempRef = refStrategy.createRefFor(entityId, this);
-            eventSystem.send(tempRef, event);
-            tempRef.invalidate();
-            finalComponents = event.getResultComponents();
-        } else {
-            finalComponents = components;
-        }
-
-        for (Component c : finalComponents) {
-            globalPool.getComponentStore().put(entityId, c);
-        }
-        return createEntityRef(entityId);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -629,20 +629,6 @@ public class PojoEntityManager implements EngineEntityManager {
         }
     }
 
-    private class EntityIterable implements Iterable<EntityRef> {
-        private TLongList list;
-
-        EntityIterable(TLongList list) {
-            this.list = list;
-        }
-
-        @Override
-        public Iterator<EntityRef> iterator() {
-            return new EntityIterator(list.iterator(), globalPool);
-        }
-    }
-
-
     public boolean registerId(long entityId) {
         if (entityId >= nextEntityId) {
             logger.error("Prevented attempt to create entity with an invalid id.");

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -293,8 +293,8 @@ public class PojoEntityManager implements EngineEntityManager {
 
 
     @Override
-    public EntityRef createEntityRefWithId(long entityId) {
-        return globalPool.createEntityRefWithId(entityId);
+    public EntityRef getEntityRef(long entityId) {
+        return globalPool.getEntityRef(entityId);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -258,15 +258,6 @@ public class PojoEntityManager implements EngineEntityManager {
     }
 
     @Override
-    public EntityRef getExistingEntity(long id) {
-        EntityRef entity = globalPool.getExistingEntity(id);
-        if (entity == EntityRef.NULL || entity == null) {
-            entity = sectorManager.getExistingEntity(id);
-        }
-        return (entity == null) ? EntityRef.NULL : entity;
-    }
-
-    @Override
     public ComponentLibrary getComponentLibrary() {
         return componentLibrary;
     }
@@ -591,7 +582,7 @@ public class PojoEntityManager implements EngineEntityManager {
         }
 
         //Return existing entity if it exists
-        EntityRef existing = getExistingEntity(entityId);
+        EntityRef existing = getEntity(entityId);
         if(existing != EntityRef.NULL && existing != null) {
             return existing;
         }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -209,11 +209,6 @@ public class PojoEntityManager implements EngineEntityManager {
     }
 
     @Override
-    public EntityRef getEntity(long id) {
-        return createEntityRef(id);
-    }
-
-    @Override
     public EntityRef create(String prefab, Vector3f position) {
         return globalPool.create(prefab, position);
     }
@@ -293,9 +288,9 @@ public class PojoEntityManager implements EngineEntityManager {
 
 
     @Override
-    public EntityRef getEntityRef(long id) {
+    public EntityRef getEntity(long id) {
         if (idLoaded(id)) {
-            return getEntityPool(id).getEntityRef(id);
+            return getEntityPool(id).getEntity(id);
         } else {
             return EntityRef.NULL;
         }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -462,7 +462,7 @@ public class PojoEntityManager implements EngineEntityManager {
             notifyComponentChanged(getEntity(entityId), component.getClass());
         }
         if (eventSystem != null) {
-            EntityRef entityRef = createEntityRef(entityId);
+            EntityRef entityRef = getEntity(entityId);
             if (oldComponent == null) {
                 eventSystem.send(entityRef, OnAddedComponent.newInstance(), component);
                 eventSystem.send(entityRef, OnActivatedComponent.newInstance(), component);
@@ -485,7 +485,7 @@ public class PojoEntityManager implements EngineEntityManager {
         T component = globalPool.getComponentStore().get(entityId, componentClass);
         if (component != null) {
             if (eventSystem != null) {
-                EntityRef entityRef = createEntityRef(entityId);
+                EntityRef entityRef = getEntity(entityId);
                 eventSystem.send(entityRef, BeforeDeactivateComponent.newInstance(), component);
                 eventSystem.send(entityRef, BeforeRemoveComponent.newInstance(), component);
             }
@@ -510,7 +510,7 @@ public class PojoEntityManager implements EngineEntityManager {
             logger.error("Saving a component ({}) that doesn't belong to this entity {}", component.getClass(), entityId);
         }
         if (eventSystem != null) {
-            EntityRef entityRef = createEntityRef(entityId);
+            EntityRef entityRef = getEntity(entityId);
             if (oldComponent == null) {
                 eventSystem.send(entityRef, OnAddedComponent.newInstance(), component);
                 eventSystem.send(entityRef, OnActivatedComponent.newInstance(), component);
@@ -544,22 +544,6 @@ public class PojoEntityManager implements EngineEntityManager {
         if (poolMap.get(entityId) != pool) {
             poolMap.put(entityId, pool);
         }
-    }
-
-    private EntityRef createEntityRef(long entityId) {
-        if (entityId == NULL_ID) {
-            return EntityRef.NULL;
-        }
-
-        //Return existing entity if it exists
-        EntityRef existing = getEntity(entityId);
-        if(existing != EntityRef.NULL && existing != null) {
-            return existing;
-        }
-
-        BaseEntityRef newRef = refStrategy.createRefFor(entityId, this);
-        globalPool.putEntity(entityId, newRef);
-        return newRef;
     }
 
     public void notifyComponentAdded(EntityRef changedEntity, Class<? extends Component> component) {
@@ -613,7 +597,7 @@ public class PojoEntityManager implements EngineEntityManager {
             List<Map.Entry<EntityRef, T>> list = new ArrayList<>();
             while (iterator.hasNext()) {
                 iterator.advance();
-                list.add(new EntityEntry<>(createEntityRef(iterator.key()), iterator.value()));
+                list.add(new EntityEntry<>(getEntity(iterator.key()), iterator.value()));
             }
             return list;
         }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -302,11 +302,7 @@ public class PojoEntityManager implements EngineEntityManager {
      */
     @Override
     public EntityRef createEntityWithoutLifecycleEvents(Iterable<Component> components) {
-        EntityRef entity = createEntity(components);
-        for (Component component: components) {
-            notifyComponentAdded(entity, component.getClass());
-        }
-        return entity;
+        return globalPool.createEntityWithoutLifecycleEvents(components);
     }
 
     /**
@@ -314,7 +310,7 @@ public class PojoEntityManager implements EngineEntityManager {
      */
     @Override
     public EntityRef createEntityWithoutLifecycleEvents(String prefabName) {
-        return createEntityWithoutLifecycleEvents(getPrefabManager().getPrefab(prefabName));
+        return globalPool.createEntityWithoutLifecycleEvents(prefabName);
     }
 
     /**
@@ -322,17 +318,7 @@ public class PojoEntityManager implements EngineEntityManager {
      */
     @Override
     public EntityRef createEntityWithoutLifecycleEvents(Prefab prefab) {
-        if (prefab != null) {
-            List<Component> components = Lists.newArrayList();
-            for (Component component : prefab.iterateComponents()) {
-                components.add(componentLibrary.copy(component));
-            }
-            components.add(new EntityInfoComponent(prefab, prefab.isPersisted(), prefab.isAlwaysRelevant()));
-
-            return createEntityWithoutLifecycleEvents(components);
-        } else {
-            return createEntityWithoutLifecycleEvents(Collections.<Component>emptyList());
-        }
+        return globalPool.createEntityWithoutLifecycleEvents(prefab);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
@@ -175,7 +175,7 @@ public class PojoEntityPool implements EngineEntityPool {
         if (!entityManager.idLoaded(entityId)) {
             return;
         }
-        EntityRef ref = createEntityRef(entityId);
+        EntityRef ref = getEntityRef(entityId);
 
         EventSystem eventSystem = entityManager.getEventSystem();
         if (eventSystem != null) {
@@ -222,15 +222,7 @@ public class PojoEntityPool implements EngineEntityPool {
         for (Component c : finalComponents) {
             componentStore.put(entityId, c);
         }
-        return createEntityRef(entityId);
-    }
-
-    @Override
-    public EntityRef createEntityRefWithId(long id) {
-        if (entityManager.isExistingEntity(id)) {
-            return createEntityRef(id);
-        }
-        return EntityRef.NULL;
+        return getEntityRef(entityId);
     }
 
     /**
@@ -280,7 +272,8 @@ public class PojoEntityPool implements EngineEntityPool {
             componentStore.put(id, c);
         }
 
-        EntityRef entity = createEntityRef(id);
+        EntityRef entity = getEntityRef(id);
+
         EventSystem eventSystem = entityManager.getEventSystem();
         if (eventSystem != null) {
             eventSystem.send(entity, OnActivatedComponent.newInstance());
@@ -342,20 +335,24 @@ public class PojoEntityPool implements EngineEntityPool {
         return componentStore;
     }
 
-    private EntityRef createEntityRef(long entityId) {
-        if (entityId == NULL_ID) {
+    @Override
+    public EntityRef getEntityRef(long entityId) {
+        if (entityId == NULL_ID || !entityManager.isExistingEntity(entityId)) {
+            // ID is null or the entity doesn't exist
             return EntityRef.NULL;
         }
+
         EntityRef existing = entityManager.getExistingEntity(entityId);
         if (existing != EntityRef.NULL && existing != null) {
-            //Entity exists, but is not in this pool
+            //Entity already has a ref
             return existing;
         }
-        //Todo: look into whether RefStrategy should use manager or pool?
-        BaseEntityRef newRef = entityManager.getEntityRefStrategy().createRefFor(entityId, entityManager);
 
-        entityStore.put(entityId, newRef);
-        return newRef;
+        BaseEntityRef entity = entityManager.getEntityRefStrategy().createRefFor(entityId, entityManager);
+
+        entityStore.put(entityId, entity);
+        entityManager.assignToPool(entityId, this);
+        return entity;
     }
 
     @SafeVarargs
@@ -365,7 +362,7 @@ public class PojoEntityPool implements EngineEntityPool {
                 //Keep entities which have all of the required components
                 .filter(id -> Arrays.stream(componentClasses)
                         .allMatch(component -> componentStore.get(id, component) != null))
-                .map(id -> createEntityRef(id))
+                .map(id -> getEntityRef(id))
                 .iterator();
     }
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
@@ -32,7 +32,6 @@ import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
-import org.terasology.protobuf.EntityData;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -342,12 +341,13 @@ public class PojoEntityPool implements EngineEntityPool {
             return EntityRef.NULL;
         }
 
-        EntityRef existing = entityManager.getExistingEntity(entityId);
+        EntityRef existing = entityStore.get(entityId);
         if (existing != EntityRef.NULL && existing != null) {
-            //Entity already has a ref
+            // Entity already has a ref
             return existing;
         }
 
+        // Create a new ref
         BaseEntityRef entity = entityManager.getEntityRefStrategy().createRefFor(entityId, entityManager);
 
         entityStore.put(entityId, entity);
@@ -381,12 +381,6 @@ public class PojoEntityPool implements EngineEntityPool {
     @Override
     public int getActiveEntityCount() {
         return entityStore.size();
-    }
-
-    @Override
-    public EntityRef getExistingEntity(long id) {
-        EntityRef entity = entityStore.get(id);
-        return (entity == null) ? EntityRef.NULL : entity;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
@@ -97,6 +97,7 @@ public class PojoEntityPool implements EngineEntityPool {
         for (Component component: components) {
             entityManager.notifyComponentAdded(entity, component.getClass());
         }
+
         return entity;
     }
 
@@ -195,7 +196,7 @@ public class PojoEntityPool implements EngineEntityPool {
     }
 
     private EntityRef createEntity(Iterable<Component> components) {
-        long entityId = entityManager.createEntity(this);
+        long entityId = entityManager.createEntity();
 
         Prefab prefab = null;
         for (Component component : components) {
@@ -345,19 +346,13 @@ public class PojoEntityPool implements EngineEntityPool {
         if (entityId == NULL_ID) {
             return EntityRef.NULL;
         }
-        EntityRef existing = entityManager.getEntity(entityId);
-        if (existing != null) {
+        EntityRef existing = entityManager.getExistingEntity(entityId);
+        if (existing != EntityRef.NULL && existing != null) {
             //Entity exists, but is not in this pool
             return existing;
         }
         //Todo: look into whether RefStrategy should use manager or pool?
         BaseEntityRef newRef = entityManager.getEntityRefStrategy().createRefFor(entityId, entityManager);
-
-        if (newRef.getComponent(EntityInfoComponent.class).scope == EntityData.Entity.Scope.SECTOR) {
-            entityManager.assignToPool(newRef, entityManager.getSectorManager());
-        } else {
-            entityManager.assignToPool(newRef, entityManager);
-        }
 
         entityStore.put(entityId, newRef);
         return newRef;

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
@@ -175,7 +175,7 @@ public class PojoEntityPool implements EngineEntityPool {
         if (!entityManager.idLoaded(entityId)) {
             return;
         }
-        EntityRef ref = getEntityRef(entityId);
+        EntityRef ref = getEntity(entityId);
 
         EventSystem eventSystem = entityManager.getEventSystem();
         if (eventSystem != null) {
@@ -222,7 +222,7 @@ public class PojoEntityPool implements EngineEntityPool {
         for (Component c : finalComponents) {
             componentStore.put(entityId, c);
         }
-        return getEntityRef(entityId);
+        return getEntity(entityId);
     }
 
     /**
@@ -272,7 +272,7 @@ public class PojoEntityPool implements EngineEntityPool {
             componentStore.put(id, c);
         }
 
-        EntityRef entity = getEntityRef(id);
+        EntityRef entity = getEntity(id);
 
         EventSystem eventSystem = entityManager.getEventSystem();
         if (eventSystem != null) {
@@ -336,7 +336,7 @@ public class PojoEntityPool implements EngineEntityPool {
     }
 
     @Override
-    public EntityRef getEntityRef(long entityId) {
+    public EntityRef getEntity(long entityId) {
         if (entityId == NULL_ID || !entityManager.isExistingEntity(entityId)) {
             // ID is null or the entity doesn't exist
             return EntityRef.NULL;
@@ -362,7 +362,7 @@ public class PojoEntityPool implements EngineEntityPool {
                 //Keep entities which have all of the required components
                 .filter(id -> Arrays.stream(componentClasses)
                         .allMatch(component -> componentStore.get(id, component) != null))
-                .map(id -> getEntityRef(id))
+                .map(id -> getEntity(id))
                 .iterator();
     }
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
@@ -145,8 +145,8 @@ public class PojoSectorManager implements EngineSectorManager {
     }
 
     @Override
-    public EntityRef createEntityRefWithId(long id) {
-        return getPool().createEntityRefWithId(id);
+    public EntityRef getEntityRef(long id) {
+        return getPool().getEntityRef(id);
     }
 
     public void destroy(long entityId) {

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
@@ -145,8 +145,8 @@ public class PojoSectorManager implements EngineSectorManager {
     }
 
     @Override
-    public EntityRef getEntityRef(long id) {
-        return getPool().getEntityRef(id);
+    public EntityRef getEntity(long id) {
+        return getPool().getEntity(id);
     }
 
     public void destroy(long entityId) {

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
@@ -144,11 +144,6 @@ public class PojoSectorManager implements EngineSectorManager {
         return getPool().createEntityWithId(id, components);
     }
 
-    @Override
-    public EntityRef getEntity(long id) {
-        return getPool().getEntity(id);
-    }
-
     public void destroy(long entityId) {
         getPool().destroy(entityId);
     }
@@ -196,15 +191,8 @@ public class PojoSectorManager implements EngineSectorManager {
     }
 
     @Override
-    public EntityRef getExistingEntity(long id) {
-        EntityRef entity;
-        for (EntityPool pool : pools) {
-            entity = pool.getExistingEntity(id);
-            if (entity != EntityRef.NULL && entity != null) {
-                return entity;
-            }
-        }
-        return EntityRef.NULL;
+    public EntityRef getEntity(long id) {
+        return entityManager.getEntity(id);
     }
 
     private EngineEntityPool getPool() {

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/EntityRefTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/EntityRefTypeHandler.java
@@ -51,7 +51,7 @@ public class EntityRefTypeHandler implements TypeHandler<EntityRef> {
     @Override
     public EntityRef deserialize(PersistedData data, DeserializationContext context) {
         if (data.isNumber()) {
-            return entityManager.getEntityRef(data.getAsLong());
+            return entityManager.getEntity(data.getAsLong());
         }
         return EntityRef.NULL;
     }
@@ -85,7 +85,7 @@ public class EntityRefTypeHandler implements TypeHandler<EntityRef> {
         TLongIterator iterator = array.getAsLongArray().iterator();
         while (iterator.hasNext()) {
             long item = iterator.next();
-            result.add(entityManager.getEntityRef(item));
+            result.add(entityManager.getEntity(item));
         }
     }
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/EntityRefTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/EntityRefTypeHandler.java
@@ -51,7 +51,7 @@ public class EntityRefTypeHandler implements TypeHandler<EntityRef> {
     @Override
     public EntityRef deserialize(PersistedData data, DeserializationContext context) {
         if (data.isNumber()) {
-            return entityManager.createEntityRefWithId(data.getAsLong());
+            return entityManager.getEntityRef(data.getAsLong());
         }
         return EntityRef.NULL;
     }
@@ -85,7 +85,7 @@ public class EntityRefTypeHandler implements TypeHandler<EntityRef> {
         TLongIterator iterator = array.getAsLongArray().iterator();
         while (iterator.hasNext()) {
             long item = iterator.next();
-            result.add(entityManager.createEntityRefWithId(item));
+            result.add(entityManager.getEntityRef(item));
         }
     }
 


### PR DESCRIPTION
This PR fixes some bugs with the sectors/pools implementation by consolidating the multiple entity retrieval methods into just one method, `getEntity`.

The existence of multiple methods to do the same thing led to code reuse, and some of the code wasn't properly changed in all locations. This caused a problem where the entity wasn't assigned a cache properly if it was created with one of the methods, leading to bugs in serialization and iteration. This PR fixes that problem, and reorganises the methods to help reduce similar bugs in the future.

The methods `createEntityRef`, `createEntityRefWithId`, `getExistingEntity`, `getEntityRef`, and `getEntity` all did the same job of returning the `EntityRef` corresponding to a given id. These are all consolidated into one method, `getEntity`, which I believe has the most descriptive name (the presence of 'create' in the name was confusing, as these methods aren't used to create entities. They are used to create an `EntityRef` corresponding to an id, but that should not have any effect on the method caller, so I believe it's best to leave it out of the name).