### PR TITLE
Sector/more fixes

### DIFF
--- a/engine-tests/src/test/java/org/terasology/entitySystem/BaseEntityRefTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/BaseEntityRefTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.terasology.assets.AssetFactory;
+import org.terasology.assets.management.AssetManager;
+import org.terasology.assets.module.ModuleAwareAssetTypeManager;
+import org.terasology.context.Context;
+import org.terasology.context.internal.ContextImpl;
+import org.terasology.engine.bootstrap.EntitySystemSetupUtil;
+import org.terasology.engine.module.ModuleManager;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.internal.PojoEntityManager;
+import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.entitySystem.prefab.PrefabData;
+import org.terasology.entitySystem.prefab.internal.PojoPrefab;
+import org.terasology.network.NetworkSystem;
+import org.terasology.protobuf.EntityData;
+import org.terasology.registry.CoreRegistry;
+import org.terasology.testUtil.ModuleManagerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ */
+public class BaseEntityRefTest {
+
+    private static Context context;
+    private PojoEntityManager entityManager;
+    //private Prefab prefab;
+    private EntityRef ref;
+
+    @BeforeClass
+    public static void setupClass() throws Exception {
+        context = new ContextImpl();
+        ModuleManager moduleManager = ModuleManagerFactory.create();
+        context.put(ModuleManager.class, moduleManager);
+        ModuleAwareAssetTypeManager assetTypeManager = new ModuleAwareAssetTypeManager();
+        assetTypeManager.registerCoreAssetType(Prefab.class,
+                (AssetFactory<Prefab, PrefabData>) PojoPrefab::new, "prefabs");
+        assetTypeManager.switchEnvironment(moduleManager.getEnvironment());
+        context.put(AssetManager.class, assetTypeManager.getAssetManager());
+        CoreRegistry.setContext(context);
+    }
+
+    @Before
+    public void setup() {
+        context.put(NetworkSystem.class, mock(NetworkSystem.class));
+        EntitySystemSetupUtil.addReflectionBasedLibraries(context);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
+        entityManager = (PojoEntityManager) context.get(EntityManager.class);
+
+        ref = entityManager.create();
+    }
+
+    @Test
+    public void testSetScope() {
+        assertEquals(ref.getScope(), EntityData.Entity.Scope.GLOBAL);
+        assertTrue(entityManager.getGlobalPool().contains(ref.getId()));
+
+        //Move into sector scope
+        ref.setScope(EntityData.Entity.Scope.SECTOR);
+        assertEquals(ref.getScope(), EntityData.Entity.Scope.SECTOR);
+        assertTrue(entityManager.getSectorManager().contains(ref.getId()));
+
+        //And move back to global scope
+        ref.setScope(EntityData.Entity.Scope.GLOBAL);
+        assertEquals(ref.getScope(), EntityData.Entity.Scope.GLOBAL);
+        assertTrue(entityManager.getGlobalPool().contains(ref.getId()));
+    }
+
+}

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityManagerTest.java
@@ -30,6 +30,7 @@ import org.terasology.engine.module.ModuleManager;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.PojoEntityManager;
+import org.terasology.entitySystem.entity.internal.PojoEntityPool;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeDeactivateComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
@@ -43,6 +44,7 @@ import org.terasology.entitySystem.stubs.EntityRefComponent;
 import org.terasology.entitySystem.stubs.IntegerComponent;
 import org.terasology.entitySystem.stubs.StringComponent;
 import org.terasology.network.NetworkSystem;
+import org.terasology.protobuf.EntityData;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.testUtil.ModuleManagerFactory;
 import org.terasology.utilities.Assets;
@@ -97,6 +99,7 @@ public class PojoEntityManagerTest {
     public void testCreateEntity() {
         EntityRef entity = entityManager.create();
         assertNotNull(entity);
+        assertEquals(entity.getScope(), EntityData.Entity.Scope.GLOBAL);
     }
 
     @Test
@@ -381,5 +384,17 @@ public class PojoEntityManagerTest {
         assertTrue(entity.exists());
         entity.destroy();
         assertTrue(entity.exists());
+    }
+
+    @Test
+    public void testMoveToPool() {
+        EntityRef entity = entityManager.create();
+        long id = entity.getId();
+
+        PojoEntityPool pool = new PojoEntityPool(entityManager);
+
+        entityManager.moveToPool(id, pool);
+
+        assertTrue(pool.contains(id));
     }
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
@@ -69,10 +69,4 @@ public interface EntityManager extends EntityPool {
      */
     ComponentLibrary getComponentLibrary();
 
-    EngineEntityPool getGlobalPool();
-
-    EngineSectorManager getSectorManager();
-
-    boolean moveToPool(long id, EngineEntityPool pool);
-
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
@@ -16,6 +16,7 @@
 package org.terasology.entitySystem.entity;
 
 import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.internal.EngineEntityPool;
 import org.terasology.entitySystem.event.internal.EventSystem;
 import org.terasology.entitySystem.metadata.ComponentLibrary;
 import org.terasology.entitySystem.prefab.PrefabManager;
@@ -70,5 +71,7 @@ public interface EntityManager extends EntityPool {
     EntityPool getGlobalPool();
 
     SectorManager getSectorManager();
+
+    boolean moveToPool(long id, EngineEntityPool pool);
 
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
@@ -17,6 +17,7 @@ package org.terasology.entitySystem.entity;
 
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.internal.EngineEntityPool;
+import org.terasology.entitySystem.entity.internal.EngineSectorManager;
 import org.terasology.entitySystem.event.internal.EventSystem;
 import org.terasology.entitySystem.metadata.ComponentLibrary;
 import org.terasology.entitySystem.prefab.PrefabManager;
@@ -68,9 +69,9 @@ public interface EntityManager extends EntityPool {
      */
     ComponentLibrary getComponentLibrary();
 
-    EntityPool getGlobalPool();
+    EngineEntityPool getGlobalPool();
 
-    SectorManager getSectorManager();
+    EngineSectorManager getSectorManager();
 
     boolean moveToPool(long id, EngineEntityPool pool);
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
@@ -170,4 +170,5 @@ public interface EntityPool {
      */
     int getActiveEntityCount();
 
+    boolean contains(long id);
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
@@ -170,5 +170,11 @@ public interface EntityPool {
      */
     int getActiveEntityCount();
 
+    /**
+     * Does this pool contain the given entity?
+     *
+     * @param id the id to search for
+     * @return true if this pool contains the entity; false otherwise
+     */
     boolean contains(long id);
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/LowLevelEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/LowLevelEntityManager.java
@@ -16,6 +16,8 @@
 package org.terasology.entitySystem.entity;
 
 import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.internal.EngineEntityPool;
+import org.terasology.entitySystem.entity.internal.EngineSectorManager;
 
 /**
  */
@@ -38,5 +40,25 @@ public interface LowLevelEntityManager extends EntityManager {
     Iterable<Component> iterateComponents(long id);
 
     void destroy(long id);
+
+    /**
+     * @return the global entity pool
+     */
+    EngineEntityPool getGlobalPool();
+
+    /**
+     * @return the sector manager
+     */
+    EngineSectorManager getSectorManager();
+
+    /**
+     * Moves the given entity into the given pool. This will move the entity and all of its components, as well as
+     * re-assigning it in the entity manager.
+     *
+     * @param id the id of the entity to move
+     * @param pool the pool to move the entity into
+     * @return whether the move was successful
+     */
+    boolean moveToPool(long id, EngineEntityPool pool);
 
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.entitySystem.entity.internal;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.LowLevelEntityManager;
@@ -34,6 +36,7 @@ import java.util.Collections;
 public abstract class BaseEntityRef extends EntityRef {
 
     protected LowLevelEntityManager entityManager;
+    private Logger logger = LoggerFactory.getLogger(BaseEntityRef.class);
 
     public BaseEntityRef(LowLevelEntityManager entityManager) {
         this.entityManager = entityManager;
@@ -92,6 +95,21 @@ public abstract class BaseEntityRef extends EntityRef {
         if (exists()) {
             EntityInfoComponent info = getEntityInfo();
             if (!info.scope.equals(scope)) {
+
+                EngineEntityPool newPool;
+                switch (scope) {
+                    case GLOBAL:
+                        newPool = entityManager.getGlobalPool();
+                        break;
+                    case SECTOR:
+                        newPool = entityManager.getSectorManager();
+                        break;
+                    default:
+                        logger.error("Unrecognised scope {}.", scope);
+                        return;
+                }
+
+                entityManager.moveToPool(getId(), newPool);
                 info.scope = scope;
                 saveComponent(info);
             }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
@@ -117,5 +117,13 @@ public interface EngineEntityManager extends LowLevelEntityManager, EngineEntity
      */
     TypeSerializationLibrary getTypeSerializerLibrary();
 
+    /**
+     * Gets the entity pool associated with a given entity.
+     *
+     * If the pool isn't assigned or the entity doesn't exist, an error is logged and the optional is returned empty
+     *
+     * @param id the id of the entity
+     * @return an {@link Optional} containing the pool if it exists, or empty
+     */
     Optional<EngineEntityPool> getPool(long id);
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
@@ -105,8 +105,6 @@ public interface EngineEntityManager extends LowLevelEntityManager, EngineEntity
      */
     void unsubscribe(EntityChangeSubscriber subscriber);
 
-    void remove(long entityId);
-
     /**
      * Sets the event system the entity manager will use to propagate life cycle events.
      *

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
@@ -103,14 +103,6 @@ public interface EngineEntityManager extends LowLevelEntityManager, EngineEntity
      */
     void unsubscribe(EntityChangeSubscriber subscriber);
 
-    void notifyComponentAdded(EntityRef changedEntity, Class<? extends Component> component);
-
-    void notifyComponentRemoved(EntityRef changedEntity, Class<? extends Component> component);
-
-    void notifyComponentChanged(EntityRef changedEntity, Class<? extends Component> component);
-
-    void notifyComponentRemovalAndEntityDestruction(long entityId, EntityRef ref);
-
     long createEntity();
 
     void remove(long entityId);

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
@@ -21,6 +21,8 @@ import org.terasology.entitySystem.entity.LowLevelEntityManager;
 import org.terasology.entitySystem.event.internal.EventSystem;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 
+import java.util.Optional;
+
 /**
  */
 public interface EngineEntityManager extends LowLevelEntityManager, EngineEntityPool {
@@ -116,4 +118,6 @@ public interface EngineEntityManager extends LowLevelEntityManager, EngineEntity
      * @return The default serialization library to use for serializing components
      */
     TypeSerializationLibrary getTypeSerializerLibrary();
+
+    Optional<EngineEntityPool> getPool(long id);
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
@@ -126,4 +126,5 @@ public interface EngineEntityManager extends LowLevelEntityManager, EngineEntity
      * @return an {@link Optional} containing the pool if it exists, or empty
      */
     Optional<EngineEntityPool> getPool(long id);
+
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
@@ -103,8 +103,6 @@ public interface EngineEntityManager extends LowLevelEntityManager, EngineEntity
      */
     void unsubscribe(EntityChangeSubscriber subscriber);
 
-    long createEntity();
-
     void remove(long entityId);
 
     /**

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityPool.java
@@ -69,4 +69,6 @@ public interface EngineEntityPool extends EntityPool {
      * @return whether the entity has the component
      */
     boolean hasComponent(long entityId, Class<? extends Component> componentClass);
+
+    void remove(long id);
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityPool.java
@@ -70,5 +70,11 @@ public interface EngineEntityPool extends EntityPool {
      */
     boolean hasComponent(long entityId, Class<? extends Component> componentClass);
 
+    /**
+     * Remove the entity from the pool. This does not destroy the entity, it only removes the {@link EntityRef}
+     * and the {@link Component}s from this pool, so that the entity can be moved to a different pool.
+     *
+     * @param id the id of the entity to remove
+     */
     void remove(long id);
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityPool.java
@@ -20,6 +20,8 @@ import org.terasology.entitySystem.entity.EntityPool;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.prefab.Prefab;
 
+import java.util.Optional;
+
 /**
  */
 public interface EngineEntityPool extends EntityPool {
@@ -72,9 +74,17 @@ public interface EngineEntityPool extends EntityPool {
 
     /**
      * Remove the entity from the pool. This does not destroy the entity, it only removes the {@link EntityRef}
-     * and the {@link Component}s from this pool, so that the entity can be moved to a different pool.
+     * and the {@link Component}s from this pool, so that the entity can be moved to a different pool. It does
+     * not invalidate the {@link EntityRef}.
+     *
+     * Returns an {@link Optional} {@link BaseEntityRef} if it was removed, ready to be put into another pool. If nothing
+     * was removed, return {@link Optional#empty()}.
      *
      * @param id the id of the entity to remove
+     * @return an optional {@link BaseEntityRef}, containing the removed entity
      */
-    void remove(long id);
+    Optional<BaseEntityRef> remove(long id);
+
+    void insertRef(BaseEntityRef ref, Iterable<Component> components);
+
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -637,16 +637,20 @@ public class PojoEntityManager implements EngineEntityManager {
     }
 
     public <T extends Component> Iterable<Map.Entry<EntityRef, T>> listComponents(Class<T> componentClass) {
-        TLongObjectIterator<T> iterator = globalPool.getComponentStore().componentIterator(componentClass);
-        if (iterator != null) {
-            List<Map.Entry<EntityRef, T>> list = new ArrayList<>();
-            while (iterator.hasNext()) {
-                iterator.advance();
-                list.add(new EntityEntry<>(getEntity(iterator.key()), iterator.value()));
+        List<TLongObjectIterator<T>> iterators = new ArrayList<>();
+        iterators.add(globalPool.getComponentStore().componentIterator(componentClass));
+        iterators.add(sectorManager.getComponentStore().componentIterator(componentClass));
+
+        List<Map.Entry<EntityRef, T>> list = new ArrayList<>();
+        for (TLongObjectIterator<T> iterator : iterators) {
+            if (iterator != null) {
+                while (iterator.hasNext()) {
+                    iterator.advance();
+                    list.add(new EntityEntry<>(getEntity(iterator.key()), iterator.value()));
+                }
             }
-            return list;
         }
-        return Collections.emptyList();
+        return list;
     }
 
     private static class EntityEntry<T> implements Map.Entry<EntityRef, T> {

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -529,14 +529,6 @@ public class PojoEntityManager implements EngineEntityManager {
      * Implementation
      */
 
-    /**
-     * Gets the entity pool associated with a given entity.
-     *
-     * If the pool isn't assigned or the entity doesn't exist, an error is logged and the optional is returned empty
-     *
-     * @param id the id of the entity
-     * @return an {@link Optional} containing the pool if it exists, or empty
-     */
     public Optional<EngineEntityPool> getPool(long id) {
         Optional<EngineEntityPool> pool = Optional.ofNullable(poolMap.get(id));
         if (!pool.isPresent()) {

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -540,10 +540,12 @@ public class PojoEntityManager implements EngineEntityManager {
     private Optional<EngineEntityPool> getEntityPool(long id) {
         Optional<EngineEntityPool> pool = Optional.ofNullable(poolMap.get(id));
         if (!pool.isPresent()) {
-            if (isExistingEntity(id)) {
-                logger.error("Entity {} doesn't have an assigned pool", id);
-            } else {
-                logger.error("Entity {} doesn't exist", id);
+            if (id != NULL_ID) {
+                if (isExistingEntity(id)) {
+                    logger.error("Entity {} doesn't have an assigned pool", id);
+                } else if (id != NULL_ID) {
+                    logger.error("Entity {} doesn't exist", id);
+                }
             }
         }
         return pool;

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -701,12 +701,23 @@ public class PojoEntityManager implements EngineEntityManager {
         return loadedIds.contains(entityId);
     }
 
-    public void remove(long entityId) {
-        loadedIds.remove(entityId);
+    @Override
+    public void remove(long id) {
+        getPool(id).ifPresent(pool -> pool.remove(id));
     }
 
     @Override
     public boolean contains(long id) {
         return globalPool.contains(id) || sectorManager.contains(id);
     }
+
+    /**
+     * Remove this id from the entity manager's list of loaded ids.
+     *
+     * @param id the id to remove
+     */
+    protected void unregister(long id) {
+        loadedIds.remove(id);
+    }
+
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -417,12 +417,12 @@ public class PojoEntityManager implements EngineEntityManager {
         getEntityPool(entityId).ifPresent(pool -> pool.destroy(entityId));
     }
 
-    @Override
-    //Todo: implement for any pool
-    public void notifyComponentRemovalAndEntityDestruction(long entityId, EntityRef ref) {
-        for (Component comp : globalPool.getComponentStore().iterateComponents(entityId)) {
-            notifyComponentRemoved(ref, comp.getClass());
-        }
+    protected void notifyComponentRemovalAndEntityDestruction(long entityId, EntityRef ref) {
+        getEntityPool(entityId)
+                .map(pool -> pool.getComponentStore().iterateComponents(entityId))
+                .orElse(Collections.emptyList())
+                .forEach(comp -> notifyComponentRemoved(ref, comp.getClass()));
+
         for (EntityDestroySubscriber destroySubscriber : destroySubscribers) {
             destroySubscriber.onEntityDestroyed(ref);
         }
@@ -556,19 +556,19 @@ public class PojoEntityManager implements EngineEntityManager {
         }
     }
 
-    public void notifyComponentAdded(EntityRef changedEntity, Class<? extends Component> component) {
+    protected void notifyComponentAdded(EntityRef changedEntity, Class<? extends Component> component) {
         for (EntityChangeSubscriber subscriber : subscribers) {
             subscriber.onEntityComponentAdded(changedEntity, component);
         }
     }
 
-    public void notifyComponentRemoved(EntityRef changedEntity, Class<? extends Component> component) {
+    protected void notifyComponentRemoved(EntityRef changedEntity, Class<? extends Component> component) {
         for (EntityChangeSubscriber subscriber : subscribers) {
             subscriber.onEntityComponentRemoved(changedEntity, component);
         }
     }
 
-    public void notifyComponentChanged(EntityRef changedEntity, Class<? extends Component> component) {
+    protected void notifyComponentChanged(EntityRef changedEntity, Class<? extends Component> component) {
         for (EntityChangeSubscriber subscriber : subscribers) {
             subscriber.onEntityComponentChange(changedEntity, component);
         }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -133,8 +133,7 @@ public class PojoEntityManager implements EngineEntityManager {
         return entity;
     }
 
-    @Override
-    public long createEntity() {
+    protected long createEntity() {
         if (nextEntityId == NULL_ID) {
             nextEntityId++;
         }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -535,7 +535,7 @@ public class PojoEntityManager implements EngineEntityManager {
             if (id != NULL_ID) {
                 if (isExistingEntity(id)) {
                     logger.error("Entity {} doesn't have an assigned pool", id);
-                } else if (id != NULL_ID) {
+                } else {
                     logger.error("Entity {} doesn't exist", id);
                 }
             }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -560,14 +560,6 @@ public class PojoEntityManager implements EngineEntityManager {
         }
     }
 
-    /**
-     * Moves the given entity into the given pool. This will move the entity and all of its components, as well as
-     * re-assigning it in the entity manager.
-     *
-     * @param id the id of the entity to move
-     * @param pool the pool to move the entity into
-     * @return whether the move was successful
-     */
     public boolean moveToPool(long id, EngineEntityPool pool) {
 
         if (getPool(id).isPresent() && getPool(id).get().equals(pool)) {

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
@@ -36,6 +36,7 @@ import org.terasology.math.geom.Vector3f;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.terasology.entitySystem.entity.internal.PojoEntityManager.NULL_ID;
 
@@ -393,17 +394,19 @@ public class PojoEntityPool implements EngineEntityPool {
         return componentStore.get(entityId, componentClass) != null;
     }
 
-    public void remove(long id) {
-        entityStore.remove(id);
+    @Override
+    public Optional<BaseEntityRef> remove(long id) {
         componentStore.remove(id);
+        return Optional.of(entityStore.get(id));
     }
 
-    /**
-     * Does this pool contain the given entity?
-     *
-     * @param id the identity to search for
-     * @return true if the pool contains the entity; false otherwise
-     */
+    @Override
+    public void insertRef(BaseEntityRef ref, Iterable<Component> components) {
+        entityStore.put(ref.getId(), ref);
+        components.forEach(comp -> componentStore.put(ref.getId(), comp));
+    }
+
+    @Override
     public boolean contains(long id) {
         return entityStore.containsKey(id);
     }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
@@ -393,4 +393,19 @@ public class PojoEntityPool implements EngineEntityPool {
         return componentStore.get(entityId, componentClass) != null;
     }
 
+    public void remove(long id) {
+        entityStore.remove(id);
+        componentStore.remove(id);
+    }
+
+    /**
+     * Does this pool contain the given entity?
+     *
+     * @param id the identity to search for
+     * @return true if the pool contains the entity; false otherwise
+     */
+    public boolean contains(long id) {
+        return entityStore.containsKey(id);
+    }
+
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
@@ -131,14 +131,17 @@ public class PojoEntityPool implements EngineEntityPool {
         EntityBuilder builder = newBuilder(prefab);
         builder.setSendLifecycleEvents(sendLifecycleEvents);
 
-        LocationComponent locationComponent = builder.getComponent(LocationComponent.class);
-        if (locationComponent != null) {
-            if (position != null) {
-                locationComponent.setWorldPosition(position);
-            }
-            if (rotation != null) {
-                locationComponent.setWorldRotation(rotation);
-            }
+        LocationComponent loc = builder.getComponent(LocationComponent.class);
+        if (loc == null && (position != null || rotation != null)) {
+            loc = new LocationComponent();
+            builder.addComponent(loc);
+        }
+
+        if (position != null) {
+            loc.setWorldPosition(position);
+        }
+        if (rotation != null) {
+            loc.setWorldRotation(rotation);
         }
 
         return builder.build();

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
@@ -189,7 +189,7 @@ public class PojoEntityPool implements EngineEntityPool {
         // Don't allow the destruction of unloaded entities.
         long entityId = ref.getId();
         entityStore.remove(entityId);
-        entityManager.remove(entityId);
+        entityManager.unregister(entityId);
         ref.invalidate();
         componentStore.remove(entityId);
     }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
@@ -26,6 +26,7 @@ import org.terasology.math.geom.Vector3f;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  */
@@ -209,10 +210,18 @@ public class PojoSectorManager implements EngineSectorManager {
     }
 
     @Override
-    public void remove(long id) {
+    public Optional<BaseEntityRef> remove(long id) {
         if (contains(id)) {
-            entityManager.getPool(id).ifPresent(pool -> pool.remove(id));
+            return entityManager.getPool(id)
+                    .flatMap(pool -> pool.remove(id));
+        } else {
+            return Optional.empty();
         }
+    }
+
+    @Override
+    public void insertRef(BaseEntityRef ref, Iterable<Component> components) {
+        getPool().insertRef(ref, components);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
@@ -208,4 +208,16 @@ public class PojoSectorManager implements EngineSectorManager {
         return false;
     }
 
+    @Override
+    public void remove(long id) {
+        if (contains(id)) {
+            entityManager.getPool(id).ifPresent(pool -> pool.remove(id));
+        }
+    }
+
+    @Override
+    public boolean contains(long id) {
+        return pools.stream().anyMatch(pool -> pool.contains(id));
+    }
+
 }


### PR DESCRIPTION
This contains fixes and improvements discussed in #2, such as making `getEntityPool` return an `Optional`, and adding `moveToPool`.

There are also some other small updates, such as renaming methods and adding more documentation.

Along with adding `moveToPool`, I updated `setScope` to automatically transfer the entities to the correct pool. It is worth noting that due to module permissions (of the `Entity.Scope` enum in `EntityData`) this can't currently be used in module code. I imagine modules will want to use it, so either changing the permissions on the enum (or moving it to somewhere else) (I haven't looked into module permissions, so I'm not sure what this involves), or implementing different methods (e.g.`setGlobalScope()`, `setSectorScope()`), is probably worthwhile.

I've also added tests for these new methods, which helped find some initial bugs (e.g. initially, the ref was destroyed, and you had to get a new ref with the id, but now the ref stays pointing to the entity). The setup code for `BaseEntityRefTest` was mostly copied from `PojoEntityManagerTest`. I'm not sure if this is the best way to do things, and it's possible that bits of it can be cut or changed to better suit this class' needs, but the testing works fine.