### PR TITLE
Sector/more fixes 2

### DIFF
--- a/engine-tests/src/test/java/org/terasology/entitySystem/BaseEntityRefTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/BaseEntityRefTest.java
@@ -38,6 +38,7 @@ import org.terasology.testUtil.ModuleManagerFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -76,16 +77,19 @@ public class BaseEntityRefTest {
     public void testSetScope() {
         assertEquals(ref.getScope(), EntityData.Entity.Scope.GLOBAL);
         assertTrue(entityManager.getGlobalPool().contains(ref.getId()));
+        assertFalse(entityManager.getSectorManager().contains(ref.getId()));
 
         //Move into sector scope
         ref.setScope(EntityData.Entity.Scope.SECTOR);
         assertEquals(ref.getScope(), EntityData.Entity.Scope.SECTOR);
         assertTrue(entityManager.getSectorManager().contains(ref.getId()));
+        assertFalse(entityManager.getGlobalPool().contains(ref.getId()));
 
         //And move back to global scope
         ref.setScope(EntityData.Entity.Scope.GLOBAL);
         assertEquals(ref.getScope(), EntityData.Entity.Scope.GLOBAL);
         assertTrue(entityManager.getGlobalPool().contains(ref.getId()));
+        assertFalse(entityManager.getSectorManager().contains(ref.getId()));
     }
 
 }

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityManagerTest.java
@@ -391,10 +391,18 @@ public class PojoEntityManagerTest {
         EntityRef entity = entityManager.create();
         long id = entity.getId();
 
-        PojoEntityPool pool = new PojoEntityPool(entityManager);
+        PojoEntityPool pool1 = new PojoEntityPool(entityManager);
+        PojoEntityPool pool2 = new PojoEntityPool(entityManager);
 
-        entityManager.moveToPool(id, pool);
+        assertFalse(pool1.contains(id));
+        assertFalse(pool2.contains(id));
 
-        assertTrue(pool.contains(id));
+        assertTrue(entityManager.moveToPool(id, pool1));
+        assertTrue(pool1.contains(id));
+        assertFalse(pool2.contains(id));
+
+        assertTrue(entityManager.moveToPool(id, pool2));
+        assertTrue(pool2.contains(id));
+        assertFalse(pool1.contains(id));
     }
 }

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityPoolTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityPoolTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.terasology.assets.AssetFactory;
+import org.terasology.assets.management.AssetManager;
+import org.terasology.assets.module.ModuleAwareAssetTypeManager;
+import org.terasology.context.Context;
+import org.terasology.context.internal.ContextImpl;
+import org.terasology.engine.bootstrap.EntitySystemSetupUtil;
+import org.terasology.engine.module.ModuleManager;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.internal.PojoEntityManager;
+import org.terasology.entitySystem.entity.internal.PojoEntityPool;
+import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.entitySystem.prefab.PrefabData;
+import org.terasology.entitySystem.prefab.internal.PojoPrefab;
+import org.terasology.network.NetworkSystem;
+import org.terasology.registry.CoreRegistry;
+import org.terasology.testUtil.ModuleManagerFactory;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ */
+public class PojoEntityPoolTest {
+
+    private PojoEntityPool pool;
+    private static Context context;
+    private PojoEntityManager entityManager;
+
+    @BeforeClass
+    public static void setupClass() throws Exception {
+        context = new ContextImpl();
+        ModuleManager moduleManager = ModuleManagerFactory.create();
+        context.put(ModuleManager.class, moduleManager);
+        ModuleAwareAssetTypeManager assetTypeManager = new ModuleAwareAssetTypeManager();
+        assetTypeManager.registerCoreAssetType(Prefab.class,
+                (AssetFactory<Prefab, PrefabData>) PojoPrefab::new, "prefabs");
+        assetTypeManager.switchEnvironment(moduleManager.getEnvironment());
+        context.put(AssetManager.class, assetTypeManager.getAssetManager());
+        CoreRegistry.setContext(context);
+    }
+
+    @Before
+    public void setup() {
+        context.put(NetworkSystem.class, mock(NetworkSystem.class));
+        EntitySystemSetupUtil.addReflectionBasedLibraries(context);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
+        entityManager = (PojoEntityManager) context.get(EntityManager.class);
+
+        pool = new PojoEntityPool(entityManager);
+    }
+
+
+    @Test
+    public void testContains() {
+        assertFalse(pool.contains(PojoEntityManager.NULL_ID));
+        assertFalse(pool.contains(1000000));
+        EntityRef ref = pool.create();
+        assertTrue(pool.contains(ref.getId()));
+    }
+
+    @Test
+    public void testRemove() {
+        EntityRef ref = pool.create();
+        assertTrue(pool.contains(ref.getId()));
+
+        pool.remove(ref.getId());
+        assertFalse(pool.contains(ref.getId()));
+    }
+
+}

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
@@ -173,7 +173,7 @@ public interface EntityPool {
     /**
      * Does this pool contain the given entity?
      *
-     * @param id the id to search for
+     * @param id the id of the entity to search for
      * @return true if this pool contains the entity; false otherwise
      */
     boolean contains(long id);

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -36,7 +36,7 @@ import java.util.Collections;
 public abstract class BaseEntityRef extends EntityRef {
 
     protected LowLevelEntityManager entityManager;
-    private Logger logger = LoggerFactory.getLogger(BaseEntityRef.class);
+    private static final Logger logger = LoggerFactory.getLogger(BaseEntityRef.class);
 
     public BaseEntityRef(LowLevelEntityManager entityManager) {
         this.entityManager = entityManager;

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityPool.java
@@ -73,18 +73,34 @@ public interface EngineEntityPool extends EntityPool {
     boolean hasComponent(long entityId, Class<? extends Component> componentClass);
 
     /**
-     * Remove the entity from the pool. This does not destroy the entity, it only removes the {@link EntityRef}
+     * Remove the entity from the pool. This does not destroy the entity, it only removes the {@link BaseEntityRef}
      * and the {@link Component}s from this pool, so that the entity can be moved to a different pool. It does
      * not invalidate the {@link EntityRef}.
      *
-     * Returns an {@link Optional} {@link BaseEntityRef} if it was removed, ready to be put into another pool. If nothing
-     * was removed, return {@link Optional#empty()}.
+     * Returns an {@link Optional} {@link BaseEntityRef} if it was removed, ready to be put into another pool. If
+     * nothing was removed, return {@link Optional#empty()}.
+     *
+     * This method is intended for use by {@link EngineEntityManager#moveToPool(long, EngineEntityPool)}. Caution
+     * should be taken if this method is used elsewhere, and the caller should ensure that the the entity is
+     * immediately placed in a new pool. All of the components are removed, so should be manually copied before this
+     * method is called if they are to be kept in use.
      *
      * @param id the id of the entity to remove
      * @return an optional {@link BaseEntityRef}, containing the removed entity
      */
     Optional<BaseEntityRef> remove(long id);
 
+    /**
+     * Insert the {@link BaseEntityRef} into this pool, with these {@link Component}s. This only inserts the ref, adds the
+     * components, and assigns the entity to this pool in the EntityManager.
+     *
+     * No events are sent, so this should only be used when inserting a ref that has been created elsewhere. It is
+     * intended for use by {@link EngineEntityManager#moveToPool(long, EngineEntityPool)}, so caution should be taken
+     * if this method is used elsewhere.
+     *
+     * @param ref the EntityRef of the entity to be inserted
+     * @param components the entity's components
+     */
     void insertRef(BaseEntityRef ref, Iterable<Component> components);
 
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -560,6 +560,20 @@ public class PojoEntityManager implements EngineEntityManager {
         }
     }
 
+    /**
+     * Remove the assignment of an entity to a pool.
+     *
+     * This does not affect anything else related to the entity, but may lead to the entity or its components being
+     * unable to be found.
+     *
+     * When using this method, be sure to properly re-assign the entity to its correct pool afterwards.
+     *
+     * @param id the id of the entity to remove the assignment for
+     */
+    protected void unassignPool(long id) {
+        poolMap.remove(id);
+    }
+
     public boolean moveToPool(long id, EngineEntityPool pool) {
 
         if (getPool(id).isPresent() && getPool(id).get().equals(pool)) {

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
@@ -400,13 +400,14 @@ public class PojoEntityPool implements EngineEntityPool {
     @Override
     public Optional<BaseEntityRef> remove(long id) {
         componentStore.remove(id);
-        return Optional.of(entityStore.get(id));
+        return Optional.of(entityStore.remove(id));
     }
 
     @Override
     public void insertRef(BaseEntityRef ref, Iterable<Component> components) {
         entityStore.put(ref.getId(), ref);
         components.forEach(comp -> componentStore.put(ref.getId(), comp));
+        entityManager.assignToPool(ref.getId(), this);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
@@ -400,6 +400,7 @@ public class PojoEntityPool implements EngineEntityPool {
     @Override
     public Optional<BaseEntityRef> remove(long id) {
         componentStore.remove(id);
+        entityManager.unassignPool(id);
         return Optional.of(entityStore.remove(id));
     }
 


### PR DESCRIPTION
This contains fixes for @skaldarnar's feedback on #3, and some updates to `moveToPool()`.

I haven't done anything with the `remove()` method apart from updating the documentation for now, warning against improper use (I've also added an equivalent message to the partnering `insertRef()` method).

I updated some of the tests, and found and fixed a bug where moveToPool wasn't properly assigning the ref to the right pool using `assignToPool()`, which led to it appearing to be in the original pool, when it was actually in the new pool.