### PR TITLE
Sector Simulation

### DIFF
--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
@@ -33,7 +33,7 @@ public interface EntityManager extends EntityPool {
      *
      * @return the newly created EntityRef
      */
-    default EntityRef createSectorEntity() {
+    default EntityRef createSectorEntity(long maxDelta) {
         return null;
     }
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -22,6 +22,7 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.LowLevelEntityManager;
 import org.terasology.entitySystem.event.Event;
 import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.entitySystem.sectors.SectorSimulationComponent;
 import org.terasology.network.NetworkComponent;
 import org.terasology.persistence.serializers.EntityDataJSONFormat;
 import org.terasology.persistence.serializers.EntitySerializer;
@@ -100,9 +101,13 @@ public abstract class BaseEntityRef extends EntityRef {
                 switch (scope) {
                     case GLOBAL:
                         newPool = entityManager.getGlobalPool();
+                        removeComponent(SectorSimulationComponent.class);
                         break;
                     case SECTOR:
                         newPool = entityManager.getSectorManager();
+                        if (!hasComponent(SectorSimulationComponent.class)) {
+                            addComponent(new SectorSimulationComponent());
+                        }
                         break;
                     default:
                         logger.error("Unrecognised scope {}.", scope);

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -39,6 +39,7 @@ import org.terasology.entitySystem.event.internal.EventSystem;
 import org.terasology.entitySystem.metadata.ComponentLibrary;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.prefab.PrefabManager;
+import org.terasology.entitySystem.sectors.SectorSimulationComponent;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
@@ -127,9 +128,14 @@ public class PojoEntityManager implements EngineEntityManager {
     }
 
     @Override
-    public EntityRef createSectorEntity() {
+    public EntityRef createSectorEntity(long maxDelta) {
         EntityRef entity = sectorManager.create();
         entity.setScope(EntityData.Entity.Scope.SECTOR);
+
+        entity.addComponent(new SectorSimulationComponent(maxDelta));
+
+        //TODO: look into keeping all sector entities loaded, or converting alwaysRelevant into another scope
+        entity.setAlwaysRelevant(true);
         return entity;
     }
 

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/LoadedSectorUpdateEvent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/LoadedSectorUpdateEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.sectors;
+
+import org.terasology.entitySystem.event.Event;
+import org.terasology.module.sandbox.API;
+
+/**
+ * This event will be sent by the {@link SectorSimulationSystem} to allow sector-scope entities to have an effect on the world,
+ * whenever the chunk they are in is loaded.
+ *
+ * This event will always be immediately preceded by a {@link SectorSimulationEvent}, so no extra simulation needs to
+ * take place for this event.
+ *
+ * TODO: This is currently sent on the same schedule as {@link SectorSimulationEvent}, based on
+ * TODO: {@link SectorSimulationComponent#maxDelta}. It should be able to have its own schedule for when the chunk is
+ * TODO: loaded.
+ */
+@API
+public class LoadedSectorUpdateEvent implements Event {
+    public LoadedSectorUpdateEvent() {
+
+    }
+}

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationComponent.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.sectors;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.internal.BaseEntityRef;
+import org.terasology.module.sandbox.API;
+import org.terasology.protobuf.EntityData;
+
+/**
+ * The component that allows the {@link SectorSimulationSystem} to send simulation events to a sector-scope entity.
+ *
+ * This should be automatically added by either {@link EntityManager#createSectorEntity(long)} or
+ * {@link BaseEntityRef#setScope(EntityData.Entity.Scope)}, so modules should not need to modify or add it.
+ */
+@API
+public class SectorSimulationComponent implements Component {
+
+    public static final float MAX_DELTA_DEFAULT = 10;
+
+    /**
+     * The maximum time that can elapse between {@link SectorSimulationEvent}s being sent. This value does not change
+     * the fact that a simulation event is always sent when the chunk the entity is in is loaded.
+     *
+     * TODO: this should only affect the timing of events sent when the chunk is not loaded; a different value should
+     * TODO: be used when the chunk is loaded. This will allow this value to be set as high as possible (or even to a
+     * TODO: non-simulating value) if all of the simulation can be postponed until chunk load.
+     *
+     * This should be set as high as possible, so that fewer simulation events need to be sent in total. The purpose of
+     * this value is to allow checking for whether its borders need to be expanded regularly, so that the appropriate
+     * events are called if those expanded regions are loaded.
+     *
+     * E.g. if a city expands while the player is away, it needs to tell the system to load buildings at the edge of
+     * the city region without the centre of the city needing to be loaded (to force a simulation).
+     */
+    public float maxDelta;
+
+    /**
+     * The last time a {@link SectorSimulationEvent} was sent to this entity.
+     *
+     * This is used to calculate the delta between simulation events, and should not be changed outside of this class
+     * or the {@link SectorSimulationSystem}.
+     */
+    protected float lastSimulationTime;
+
+    /**
+     * Create a new {@link SectorSimulationComponent} with the default max delta.
+     */
+    public SectorSimulationComponent() {
+        new SectorSimulationComponent(MAX_DELTA_DEFAULT);
+    }
+
+    /**
+     * @see SectorSimulationComponent#maxDelta
+     */
+    public SectorSimulationComponent(float maxDelta) {
+        this.maxDelta = maxDelta;
+    }
+}

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationEvent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationEvent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.sectors;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+import org.terasology.module.sandbox.API;
+
+/**
+ * This is the event sent to all sector-level entities by the {@link SectorSimulationSystem}, allowing them to do simulation. It
+ * is sent regardless of whether the chunk the entity is in is loaded or not.
+ *
+ * @see SectorSimulationEvent#getDelta()
+ */
+@API
+public class SectorSimulationEvent implements Event {
+    private float delta;
+
+    /**
+     * @see SectorSimulationEvent#getDelta() for the delta parameter
+     */
+    protected SectorSimulationEvent(float delta) {
+        this.delta = delta;
+    }
+
+    /**
+     * This gives the time elapsed, in seconds, since the last time this event was sent to the given {@link EntityRef}.
+     *
+     * Performing simulation based on the the number of times this event is sent is not reliable, because there may be
+     * big variations in the time between sending these events (notably, an event will be sent whenever the chunk an
+     * entity is in is loaded, even if one has just been sent.
+     *
+     * Using the delta will give a relaible measure of how much simulation to perform.
+     *
+     * @return the time, in seconds, since the last time this event was sent to the given entity
+     */
+    public float getDelta() {
+        return delta;
+    }
+}

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationSystem.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationSystem.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.sectors;
+
+import org.terasology.engine.Time;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.internal.BaseEntityRef;
+import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnAddedComponent;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnChangedComponent;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.delay.DelayManager;
+import org.terasology.logic.delay.PeriodicActionTriggeredEvent;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.ChunkMath;
+import org.terasology.protobuf.EntityData;
+import org.terasology.registry.In;
+import org.terasology.world.WorldComponent;
+import org.terasology.world.WorldProvider;
+import org.terasology.world.chunks.event.BeforeChunkUnload;
+import org.terasology.world.chunks.event.OnChunkLoaded;
+
+/**
+ * This system handles the sending of sector-level simulation events, so module systems can subscribe to them for their
+ * own sector-scope entities.
+ *
+ * For the purposes of this class, sector-scope means any {@link EntityRef} that's scope is SECTOR, and that has a
+ * {@link SectorSimulationComponent}. The entity should automatically have the component, as long as it was created by
+ * {@link EntityManager#createSectorEntity(long)} or its scope was set by
+ * {@link BaseEntityRef#setScope(EntityData.Entity.Scope)}.
+ *
+ * It periodically sends a {@link SectorSimulationEvent} to all sector-scope entities, which should trigger any
+ * simulation that needs to happen regardless of whether or not the entity's chunk is loaded.
+ *
+ * It periodically sends a {@link LoadedSectorUpdateEvent} to all sector-scope entities which are in a loaded chunk.
+ * This should trigger any block-based or chunk-based actions that need to happen.
+ *
+ * It also sends {@link OnChunkLoaded} and {@link BeforeChunkUnload} events to the entities, where appropriate. These
+ * should be captured by filtering only to entities with a {@link SectorSimulationComponent}, to avoid capturing the
+ * event sent to the world entity.
+ */
+@RegisterSystem
+public class SectorSimulationSystem extends BaseComponentSystem {
+
+    @In
+    private EntityManager entityManager;
+
+    @In
+    private WorldProvider worldProvider;
+
+    @In
+    private DelayManager delayManager;
+
+    @In
+    private Time time;
+
+    public static final String SECTOR_SIMULATION_ACTION = "sector:simulationAction";
+
+
+    /* Set periodic events for each entity */
+
+
+    @ReceiveEvent(components = SectorSimulationComponent.class)
+    public void simulationComponentAdded(OnAddedComponent event, EntityRef entity) {
+        registerSimulationComponent(entity);
+    }
+
+    @ReceiveEvent(components = SectorSimulationComponent.class)
+    public void simulationComponentChanged(OnChangedComponent event, EntityRef entity) {
+        registerSimulationComponent(entity);
+    }
+
+    @ReceiveEvent(components = SectorSimulationComponent.class)
+    public void simulationComponentRemoved(BeforeRemoveComponent event, EntityRef entity) {
+        unregisterSimulationComponent(entity);
+    }
+
+    /**
+     * Add the sector simulation periodic action event for this sector-level entity.
+     *
+     * This event will be sent on a schedule based on {@link SectorSimulationComponent#maxDelta}, and will be used to
+     * send {@link SectorSimulationEvent} and/or {@link LoadedSectorUpdateEvent}, as appropriate.
+     *
+     * This periodic event gets processed by
+     * {@link SectorSimulationSystem#processPeriodicSectorEvent(PeriodicActionTriggeredEvent, EntityRef)};
+     *
+     * @param entity the entity to add the periodic event for
+     */
+    private void registerSimulationComponent(EntityRef entity) {
+        SectorSimulationComponent simulationComponent = entity.getComponent(SectorSimulationComponent.class);
+
+        unregisterSimulationComponent(entity);
+        delayManager.addPeriodicAction(entity, SECTOR_SIMULATION_ACTION, 0, (long) (simulationComponent.maxDelta * 1000));
+    }
+
+    /**
+     * Cancel any sector simulation periodic event for this sector-level entity
+     *
+     * @param entity the event to cancel the periodic event for
+     */
+    private void unregisterSimulationComponent(EntityRef entity) {
+        if (delayManager.hasPeriodicAction(entity, SECTOR_SIMULATION_ACTION)) {
+            delayManager.cancelPeriodicAction(entity, SECTOR_SIMULATION_ACTION);
+        }
+    }
+
+
+    /* Send events for the module to capture */
+
+
+    /**
+     * Retrieve the periodic event sent to each sector-scope entity, and send the appropriate event(s) depending on the
+     * status of the the chunk the entity is in.
+     *
+     * Also send the correct delta, and update the {@link SectorSimulationComponent#lastSimulationTime}.
+     *
+     * @param event the periodic action event sent at intervals of {@link SectorSimulationComponent#maxDelta}
+     * @param entity the sector-scope entity the event was sent to
+     */
+    @ReceiveEvent(components = SectorSimulationComponent.class)
+    public void processPeriodicSectorEvent(PeriodicActionTriggeredEvent event, EntityRef entity) {
+        if (event.getActionId().equals(SECTOR_SIMULATION_ACTION)) {
+            float delta = simulationDelta(entity);
+
+            LocationComponent loc = entity.getComponent(LocationComponent.class);
+            if (loc != null && worldProvider.isBlockRelevant(loc.getWorldPosition())) {
+                sendLoadedSectorUpdateEvent(entity, delta);
+            } else {
+                entity.send(new SectorSimulationEvent(delta));
+            }
+        }
+    }
+
+    /**
+     * Forward the OnChunkLoaded event to the appropriate sector-scope entities, if their chunk was loaded.
+     *
+     * @param event the event sent when any chunk is loaded
+     * @param worldEntity ignored
+     */
+    @ReceiveEvent(components = WorldComponent.class)
+    public void forwardOnChunkLoaded(OnChunkLoaded event, EntityRef worldEntity) {
+        for (EntityRef entity : entityManager.getEntitiesWith(SectorSimulationComponent.class)) {
+            LocationComponent loc = entity.getComponent(LocationComponent.class);
+            if (loc != null && ChunkMath.calcChunkPos(loc.getWorldPosition()).equals(event.getChunkPos())) {
+                entity.send(new OnChunkLoaded(event.getChunkPos()));
+                sendLoadedSectorUpdateEvent(entity, simulationDelta(entity));
+            }
+        }
+    }
+
+    /**
+     * Forward the BeforeChunkUnloaded event to the appropriate sector-scope entities, if their chunk was unloaded.
+     *
+     * @param event the event sent when any chunk is about to be unloaded
+     * @param worldEntity ignored
+     */
+    @ReceiveEvent(components = WorldComponent.class)
+    public void forwardChunkUnload(BeforeChunkUnload event, EntityRef worldEntity) {
+        for (EntityRef entity : entityManager.getEntitiesWith(SectorSimulationComponent.class)) {
+            LocationComponent loc = entity.getComponent(LocationComponent.class);
+            if (loc != null && ChunkMath.calcChunkPos(loc.getWorldPosition()).equals(event.getChunkPos())) {
+                entity.send(new BeforeChunkUnload(event.getChunkPos()));
+            }
+        }
+    }
+
+    /**
+     * Send the appropriate events to a sector-scope entity in a loaded chunk.
+     *
+     * @param entity the entity to send the events to
+     * @param delta the time since the last time {@link SectorSimulationEvent} was sent
+     */
+    private void sendLoadedSectorUpdateEvent(EntityRef entity, float delta) {
+        entity.send(new SectorSimulationEvent(delta));
+        entity.send(new LoadedSectorUpdateEvent());
+    }
+
+    /**
+     * Calculate the time since the last {@link SectorSimulationEvent} was sent. This also updates the
+     * {@link SectorSimulationComponent#lastSimulationTime}, so future deltas will be correct.
+     * @param entity
+     * @return
+     */
+    private float simulationDelta(EntityRef entity) {
+        SectorSimulationComponent simulationComponent = entity.getComponent(SectorSimulationComponent.class);
+        float currentTime = time.getGameTime();
+        if (simulationComponent.lastSimulationTime == 0) {
+            simulationComponent.lastSimulationTime = currentTime;
+        }
+        float delta = currentTime - simulationComponent.lastSimulationTime;
+        simulationComponent.lastSimulationTime = currentTime;
+        return delta;
+    }
+
+}


### PR DESCRIPTION
This PR includes the mechanisms to allow sector-scope entities to perform simulation tasks. The bulk of the work is done by the `SectorSimulationSystem`, which sends events to allow sector-scope entities to work.

The `SectorSimulationEvent` is sent repeatedly, whether or not the chunk the entity is in is loaded. It will be sent at least once every `maxDelta` (defined in the `SectorSimulationComponent`, which holds information for calculating the simulation delta), but might be sent more often (e.g. it is always sent when the chunk is loaded). This should be used for any calculations and simulation the entity needs to do.

TODO: add another property so that the simulation rate can be adjusted when the entity is loaded

The `LoadedSectorUpdateEvent` is sent repeatedly, but only while the chunk the entity is in is loaded. This is where any effects on the world should take place, as the chunk is guaranteed to be loaded whenever this is sent. A `SectorSimulationEvent` is always sent immediately prior to this one, so no simulation needs to happen in reaction to this event.

The OnChunkLoaded and BeforeChunkLoaded also get forwarded to the appropriate sector entities when their chunks are affected, so certain things can be done on chunk load/unload (e.g. caching some data to use when the chunk is unloaded). A `LoadedSectorUpdateEvent` is automatically sent immediately after the `OnChunkLoaded` event, so this only needs to be used for things that don't normally get simulated (e.g. generating new villager entities).

See the [SectorTesting](https://github.com/Vizaxo/SectorTesting/blob/master/src/main/java/org/terasology/sectorTesting/TestSystem.java) module for an example of how it is implemented.